### PR TITLE
Update alpine version to 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.18.2
 COPY ping /
 
 HEALTHCHECK --interval=5s --timeout=3s \


### PR DESCRIPTION
This MR introduces an upgrade to Alpine Linux version 3.18.2, due to its enhanced security, bug fixes, and performance improvements.